### PR TITLE
SP style調整

### DIFF
--- a/src/components/catch/PageCatch.astro
+++ b/src/components/catch/PageCatch.astro
@@ -39,4 +39,13 @@ const { page } = Astro.props;
     margin: auto;
     height: 50px;
   }
+  @media screen and (max-width: $mobileBreakPoint) {
+    .page_title {
+      padding-left: vw(30px);
+      height: auto;
+      top: 50%;
+      bottom: auto;
+      transform: translateY(-50%);
+    }
+  }
 </style>

--- a/src/components/catch/TopCatch.astro
+++ b/src/components/catch/TopCatch.astro
@@ -47,9 +47,10 @@ import Logo from "~/img/top/top_logo.png";
     @media screen and (min-width: 1650px) {
       top: 100px;
     }
-    @media screen and (min-width: $mobileBreakPoint) {
-      width: vw(140px);
-      height: vw(43px);
+    @media screen and (max-width: $mobileBreakPoint) {
+      width: vw(126px);
+      height: vw(44px);
+      top: 50px;
     }
   }
   .sub_copy {
@@ -57,7 +58,7 @@ import Logo from "~/img/top/top_logo.png";
     font-weight: bold;
     margin-top: 78px;
     font-size: 19px;
-    @media screen and (min-width: $mobileBreakPoint) {
+    @media screen and (max-width: $mobileBreakPoint) {
       display: none;
     }
   }
@@ -71,7 +72,7 @@ import Logo from "~/img/top/top_logo.png";
     left: 0;
     right: 0;
     text-align: center;
-    @media screen and (min-width: $mobileBreakPoint) {
+    @media screen and (max-width: $mobileBreakPoint) {
       display: none;
     }
     &:before {

--- a/src/components/common/AboutModelHouse.astro
+++ b/src/components/common/AboutModelHouse.astro
@@ -14,14 +14,12 @@ import ModelImage from "~/img/model_image.png";
       モデルハウスは貸しスペースも行っており、ヨガ教室や料理教室、韓国語講座などにもご利用いただいています。<br
       />
       <br />
-      モデルハウス見学ご希望の方は、<a href="tel:0120-200-789">0120-200-789</a
+      モデルハウス見学ご希望の方は、<br class="sp"><a href="tel:0120-200-789">0120-200-789</a
       >まで事前にご予約ください。<br />
       <br />
       <dl class="contact">
         <dt>営業時間</dt><dd>10:00～17:00（水曜定休）</dd>
-        <dt>所在地</dt><dd>福岡県太宰府市通古賀5-2-3</dd>
-        <dt>&emsp;</dt><dd>※駐車場あり</dd>
-        <dt>&emsp;</dt><dd>※西鉄大牟田線都府楼前駅より徒歩１０分</dd>
+        <dt>所在地</dt><dd>福岡県太宰府市通古賀5-2-3<br>※駐車場あり<br>※西鉄大牟田線都府楼前駅より徒歩１０分</dd>
       </dl>
     </div>
   </div>
@@ -46,9 +44,42 @@ import ModelImage from "~/img/model_image.png";
       }
       .contact {
         padding-left: 30px;
+        display: flex;
+        flex-wrap: wrap;
         dt {
-          width: 100px;
-          float: left;
+          width: 18%;
+        }
+        dd {
+          width: 82%;
+        }
+      }
+    }
+    @media screen and (max-width: $mobileBreakPoint) {
+      .about_modelhouse {
+        padding: 0 vw(43px);
+        h2 {
+          margin-bottom: vw(36px);
+        }
+        .content {
+          flex-direction: column;
+          img {
+            margin-bottom: vw(23px);
+          }
+          .text {
+            font-size: vw(14px);
+          }
+        }
+        .contact {
+          padding: 0;
+          dt {
+            width: 100%;
+          }
+          dd {
+            width: 100%;
+            &:not(:last-child) {
+              margin-bottom: vw(23px);
+            }
+          }
         }
       }
     }

--- a/src/components/common/BreadCrumb.astro
+++ b/src/components/common/BreadCrumb.astro
@@ -44,4 +44,10 @@ const pageTitle = propTitle || PAGES[page].title;
       content: ">";
     }
   }
+  @media screen and (max-width: $mobileBreakPoint) {
+    .breadcrumb {
+      margin-top: vw(19px);
+      padding: 0 vw(36px);
+    }
+  }
 </style>

--- a/src/components/common/ContentBanner.astro
+++ b/src/components/common/ContentBanner.astro
@@ -54,4 +54,9 @@ import BannerAkiya from "~/img/banner_akiya.png";
       margin-left: 96px;
     }
   }
+  @media screen and (max-width: $mobileBreakPoint) {
+    .content-banner {
+      display: none;
+    }
+  }
 </style>

--- a/src/components/common/InquiryMore.astro
+++ b/src/components/common/InquiryMore.astro
@@ -7,7 +7,7 @@
   >
   <a class="more_link" href="/siryo">＞メールで相談してみる</a>
 </div>
-<style>
+<style lang="scss">
   .inquiry_more {
     display: flex;
     justify-content: center;
@@ -19,4 +19,19 @@
     font-weight: bold;
     margin-top: 167px;
   }
+  @media screen and (max-width: $mobileBreakPoint) {
+		.inquiry_more {
+      display: block;
+      text-align: center;
+      padding: 0 vw(31px);
+      margin-bottom: vw(100px);
+    }
+    .more_link {
+      padding: 0;
+      margin: 0;
+      &:not(:last-child) {
+        margin-bottom: vw(25px);
+      }
+    }
+	}
 </style>

--- a/src/components/common/LoopSection.astro
+++ b/src/components/common/LoopSection.astro
@@ -16,6 +16,7 @@ const { contents, class: className } = Astro.props;
   {
     contents.map((content) => (
       <section class="loop_content">
+        <h4 class="content_title sp">{content.title}</h4>
         <Image
           src={content.image}
           alt={content.title}
@@ -23,7 +24,7 @@ const { contents, class: className } = Astro.props;
           height={327}
         />
         <div>
-          <h4 class="content_title">{content.title}</h4>
+          <h4 class="content_title pc">{content.title}</h4>
           <p class="content_text" set:html={content.text} />
         </div>
       </section>
@@ -55,4 +56,24 @@ const { contents, class: className } = Astro.props;
   .content_text {
     line-height: 2;
   }
+  @media screen and (max-width: $mobileBreakPoint) {
+    .loop_section {
+      margin-bottom: vw(50px);
+    }
+		.loop_content {
+      flex-direction: column;
+      max-width: 100%;
+      padding: 0 vw(31px);
+      img {
+        margin-bottom: vw(25px);
+      }
+      + .loop_content {
+        flex-direction: column;
+        margin-top: vw(50px);
+      }
+    }
+    .content_title {
+      margin-bottom: vw(25px);
+    }
+	}
 </style>

--- a/src/components/common/PageCopy.astro
+++ b/src/components/common/PageCopy.astro
@@ -22,4 +22,17 @@ const { title } = Astro.props;
     margin-top: 119px;
     line-height: 2.5;
   }
+  @media screen and (max-width: $mobileBreakPoint) {
+    .page_copy {
+      line-height: vw(30px);
+      padding: 0 vw(35px);
+    }
+    .copy_title {
+      margin-top: vw(61px);
+    }
+    .copy_content {
+      line-height: vw(30px);
+      margin-top: vw(45px);
+    }
+  }
 </style>

--- a/src/components/global/Footer.astro
+++ b/src/components/global/Footer.astro
@@ -46,7 +46,7 @@ import { PAGES } from "../../consts";
   </div>
   <div class="footer-sns">
     <SNSList />
-    <small>Copyright©イエノコト株式会社　 All Rgiths Reserved</small>
+    <small>Copyright©イエノコト株式会社<span class="pc">　 </span><br class="sp">All Rgiths Reserved</small>
   </div>
   <a href="#head" class="goback fade" data-show-position={100} title="上に戻る"
   ></a>
@@ -54,7 +54,7 @@ import { PAGES } from "../../consts";
 <style lang="scss">
   footer {
     min-height: 318px;
-    background-color: #6c6c60;
+    background-color: rgba(#6c6c60, 0.72);
   }
   .footer-content {
     color: #fff;
@@ -117,12 +117,20 @@ import { PAGES } from "../../consts";
   }
   @media screen and (max-width: $mobileBreakPoint) {
     .footer-sns {
+      background: none;
+      min-height: 0;
+      padding: vw(23px) 0 vw(30px);
+      small {
+        line-height: vw(20px);
+        margin: 0;
+      }
     }
     :global(.sns_list) {
       display: none;
     }
     .footer-content {
       flex-direction: column-reverse;
+      padding: 0 vw(43px);
     }
     .footer-right {
       margin-top: vw(43px);
@@ -154,6 +162,9 @@ import { PAGES } from "../../consts";
       margin-bottom: 0px;
       width: vw(195px);
       height: vw(43px);
+    }
+    .goback {
+      display: none;
     }
   }
 </style>

--- a/src/components/global/Navi.astro
+++ b/src/components/global/Navi.astro
@@ -52,6 +52,9 @@ const isHome = Astro.url.pathname === "/";
     height: 85px;
     line-height: 85px;
     background-color: rgba($color: #6c6c60, $alpha: 0.72);
+    @media screen and (max-width: $mobileBreakPoint) {
+      background: none;
+    }
     .wrap {
       max-width: 1676px;
       margin: auto;
@@ -62,9 +65,17 @@ const isHome = Astro.url.pathname === "/";
         padding-right: 130px;
         justify-content: space-between;
       }
+      > a {
+        @media screen and (max-width: $mobileBreakPoint) {
+          pointer-events: none;
+        }
+      }
     }
     .logo {
       margin-top: 21px;
+      @media screen and (max-width: $mobileBreakPoint) {
+        opacity: 0;
+      }
     }
     li {
       color: #fff;
@@ -128,13 +139,16 @@ const isHome = Astro.url.pathname === "/";
     .slide_bar {
       display: block;
       width: 100%;
-      border-top: solid 4px white;
+      border-top: solid 4px #707070;
       margin-bottom: 10px;
       border-radius: 5px;
       transition: transform 0.25s ease;
     }
   }
   :global(.open) {
+    .slide_bar {
+      border-color: white;
+    }
     .slide_bar:first-child {
       -webkit-transform: rotate(45deg);
       -moz-transform: rotate(45deg);

--- a/src/components/global/SNSList.astro
+++ b/src/components/global/SNSList.astro
@@ -42,4 +42,13 @@ import Youtube from "~/img/sns_youtube.png";
       }
     }
   }
+  @media screen and (max-width: $mobileBreakPoint) {
+    .sns_list {
+      ul {
+        flex-direction: column;
+        align-items: center;
+        gap: vw(37px);
+      }
+    }
+  }
 </style>

--- a/src/components/home/TopNavi.astro
+++ b/src/components/home/TopNavi.astro
@@ -206,6 +206,12 @@ const navContents: NavContent[] = [
   }
   @media screen and (max-width: $mobileBreakPoint) {
     .top_nav {
+      ul {
+        padding: 0 vw(25px);
+      }
+      .title_box {
+        width: calc(100% - 48px);
+      }
       .title {
         font-size: vw(21px);
       }

--- a/src/components/post/ReformCaseList.astro
+++ b/src/components/post/ReformCaseList.astro
@@ -73,4 +73,9 @@ const ReformPosts = [
     justify-content: center;
     column-gap: 53px;
   }
+  @media screen and (max-width: $mobileBreakPoint) {
+    ul {
+      gap: vw(21px);
+    }
+  }
 </style>

--- a/src/layouts/PageContent.astro
+++ b/src/layouts/PageContent.astro
@@ -34,6 +34,11 @@ const { class: className } = Astro.props;
       footer {
         margin-top: 169px;
       }
+      @media screen and (max-width: $mobileBreakPoint) {
+        footer {
+          margin-top: vw(80px);
+        }
+      }
     </style>
   </body>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -40,9 +40,8 @@ const { className } = PAGES.HOME;
       font-size: 24px;
     }
     @media screen and (max-width: $mobileBreakPoint) {
-      margin-top: vw(77px);
+      margin: vw(75px) 0;
       line-height: calc(30 / 16);
-      margin-bottom: vw(11px);
       strong {
         font-size: vw(18px);
         padding-top: vw(48px);
@@ -52,6 +51,9 @@ const { className } = PAGES.HOME;
   }
   .sns_list_title {
     margin-bottom: 110px;
+    @media screen and (max-width: $mobileBreakPoint) {
+      margin-bottom: vw(45px);
+    }
   }
   .home {
     :global(.top_nav) {
@@ -67,6 +69,7 @@ const { className } = PAGES.HOME;
       margin-bottom: 252px;
     }
     :global(.sns_list) {
+      display: block;
       margin-bottom: 249px;
     }
     @media screen and (max-width: $mobileBreakPoint) {
@@ -83,7 +86,7 @@ const { className } = PAGES.HOME;
         margin-bottom: vw(92px);
       }
       :global(.sns_list) {
-        margin-bottom: vw(102px);
+        margin-bottom: vw(100px);
       }
     }
   }

--- a/src/pages/reform.astro
+++ b/src/pages/reform.astro
@@ -44,4 +44,15 @@ import InquiryMore from "~/components/common/InquiryMore.astro";
   .reform :global(.more_link) {
     padding-bottom: 404px;
   }
+  @media screen and (max-width: $mobileBreakPoint) {
+    .about_title {
+      margin: vw(100px) 0 vw(45px);
+    }
+    .reform_case_title {
+      margin: vw(100px) 0 vw(43px);
+    }
+    .reform :global(.more_link) {
+      padding-bottom: 0;
+    }
+  }
 </style>

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -13,12 +13,17 @@ html {
 	font-size: $baseFontSize;
 	word-wrap: break-word;
 	overflow-wrap: break-word;
+	overflow-x: hidden;
 	line-height: 1.5;
 	color: #000;
 
 	@media screen and (max-width: $mobileBreakPoint) {
 		font-size: vw($baseFontSize);
 	}
+}
+
+body {
+	overflow: hidden;
 }
 
 .pc {
@@ -58,16 +63,30 @@ b {
 h1 {
 	font-size: rem(50px);
 	text-align: center;
+	@media screen and (max-width: $mobileBreakPoint) {
+		font-size: vw(18px);
+	}
 }
 
 h2 {
 	font-size: rem(24px);
 	text-align: center;
+	@media screen and (max-width: $mobileBreakPoint) {
+		font-size: vw(18px);
+	}
 }
 
 h3 {
 	font-size: rem(18px);
 	text-align: center;
+}
+
+h4 {
+	@media screen and (max-width: $mobileBreakPoint) {
+		text-align: center;
+		font-size: vw(18px);
+		line-height: vw(30px);
+	}
 }
 
 a {


### PR DESCRIPTION
### やったこと
- トップページ、下層コンポーネントのSP用スタイル調整
- 現状320px～375pxまでしか見ていないので、それ以上のデバイス幅で崩れる可能性有り
※稼働：1営（時間あるとか言ってたのにすみません…、平日も時間ある時に地道に進めます…）
※スタイル調整だけならあと1営あればできそうです

### 確認事項
**【トップページ】**
- トップのキャッチロゴはSP用画像書き出したほうがいいか
- ラフで貸しスペースの写真がPCとSPで異なるがラフ通りでいいか

**【家をつくる】**
- 「過去の施工事例はこちら」のスライダー、実装方法の指定はあるか